### PR TITLE
fix: return @@context even when the unless block is not executed.

### DIFF
--- a/lib/ruby-nfc/nfc.rb
+++ b/lib/ruby-nfc/nfc.rb
@@ -19,6 +19,7 @@ module NFC
       LibNFC.nfc_init(ptr)
       @@context = ptr.read_pointer
     end
+    @@context
   end
 
   def self.logger


### PR DESCRIPTION
When I run the example script, the following output is encountered:

````
D, [2017-06-29T16:13:24.352294 #2174] DEBUG -- : Library version: libnfc-1.7.1-187-g14f48d0
D, [2017-06-29T16:13:24.354756 #2174] DEBUG -- : Available readers: [#<NFC::Reader:0xcb9d30 @name="acr122_usb:001:007", @ptr=nil>]
/usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:12: [BUG] Segmentation fault at 0x00140c
ruby 2.4.0p0 (2016-12-24 revision 57164) [armv7l-linux-eabihf]

-- Control frame information -----------------------------------------------
c:0005 p:---- s:0024 e:000023 CFUNC  :nfc_open
c:0004 p:0034 s:0018 e:000017 METHOD /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:12
c:0003 p:0008 s:0014 e:000013 METHOD /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:48
c:0002 p:0146 s:0007 E:00093c EVAL   reader.rb:15 [FINISH]
c:0001 p:0000 s:0003 E:001490 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
reader.rb:15:in `<main>'
/usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:48:in `poll'
/usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:12:in `connect'
/usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:12:in `nfc_open'

-- Other runtime information -----------------------------------------------

* Loaded script: reader.rb

* Loaded features:

    0 enumerator.so
    1 thread.rb
    2 rational.so
    3 complex.so
    4 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/armv7l-linux-eabihf/enc/encdb.so
    5 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/armv7l-linux-eabihf/enc/trans/transdb.so
    6 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/unicode_normalize.rb
    7 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/armv7l-linux-eabihf/rbconfig.rb
    8 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/compatibility.rb
    9 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/defaults.rb
   10 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/deprecate.rb
   11 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/errors.rb
   12 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/version.rb
   13 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/requirement.rb
   14 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/platform.rb
   15 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/basic_specification.rb
   16 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/stub_specification.rb
   17 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/util/list.rb
   18 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/armv7l-linux-eabihf/stringio.so
   19 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/specification.rb
   20 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/exceptions.rb
   21 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/dependency.rb
   22 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_gem.rb
   23 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/monitor.rb
   24 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb
   25 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems.rb
   26 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/rubygems/path_support.rb
   27 /usr/local/rvm/gems/ruby-2.4.0@global/gems/did_you_mean-1.1.0/lib/did_you_mean/version.rb
   28 /usr/local/rvm/gems/ruby-2.4.0@global/gems/did_you_mean-1.1.0/lib/did_you_mean/core_ext/name_error.rb
   29 /usr/local/rvm/gems/ruby-2.4.0@global/gems/did_you_mean-1.1.0/lib/did_you_mean/levenshtein.rb
   30 /usr/local/rvm/gems/ruby-2.4.0@global/gems/did_you_mean-1.1.0/lib/did_you_mean/jaro_winkler.rb
   31 /usr/local/rvm/gems/ruby-2.4.0@global/gems/did_you_mean-1.1.0/lib/did_you_mean/spell_checker.rb
   32 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/delegate.rb
   33 /usr/local/rvm/gems/ruby-2.4.0@global/gems/did_you_mean-1.1.0/lib/did_you_mean/spell_checkers/name_error_checkers/class_name_checker.rb
   34 /usr/local/rvm/gems/ruby-2.4.0@global/gems/did_you_mean-1.1.0/lib/did_you_mean/spell_checkers/name_error_checkers/variable_name_checker.rb
   35 /usr/local/rvm/gems/ruby-2.4.0@global/gems/did_you_mean-1.1.0/lib/did_you_mean/spell_checkers/name_error_checkers.rb
   36 /usr/local/rvm/gems/ruby-2.4.0@global/gems/did_you_mean-1.1.0/lib/did_you_mean/spell_checkers/method_name_checker.rb
   37 /usr/local/rvm/gems/ruby-2.4.0@global/gems/did_you_mean-1.1.0/lib/did_you_mean/spell_checkers/null_checker.rb
   38 /usr/local/rvm/gems/ruby-2.4.0@global/gems/did_you_mean-1.1.0/lib/did_you_mean/formatter.rb
   39 /usr/local/rvm/gems/ruby-2.4.0@global/gems/did_you_mean-1.1.0/lib/did_you_mean.rb
   40 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb
   41 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi_c.so
   42 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/platform.rb
   43 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/types.rb
   44 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/library.rb
   45 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/errno.rb
   46 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/pointer.rb
   47 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/memorypointer.rb
   48 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/struct_layout_builder.rb
   49 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/struct.rb
   50 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/union.rb
   51 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/managedstruct.rb
   52 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/callback.rb
   53 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/io.rb
   54 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/autopointer.rb
   55 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/variadic.rb
   56 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/enum.rb
   57 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi/ffi.rb
   58 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi.rb
   59 /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/logger.rb
   60 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/libnfc.rb
   61 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/nfc.rb
   62 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/tags/tag.rb
   63 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/tags/mifare/tag.rb
   64 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/tags/mifare/classic.rb
   65 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/tags/mifare/ultralight.rb
   66 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/apdu/apdu.rb
   67 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/apdu/request.rb
   68 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/apdu/response.rb
   69 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/tags/isodep.rb
   70 /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc.rb

* Process memory map:

00010000-00011000 r-xp 00000000 b3:02 269468     /usr/local/rvm/rubies/ruby-2.4.0/bin/ruby
00020000-00021000 rw-p 00000000 b3:02 269468     /usr/local/rvm/rubies/ruby-2.4.0/bin/ruby
00b69000-00e5d000 rw-p 00000000 00:00 0          [heap]
7659b000-766e0000 r-xp 00000000 b3:02 25944      /usr/lib/arm-linux-gnueabihf/libcrypto.so.1.0.0
766e0000-766f0000 ---p 00145000 b3:02 25944      /usr/lib/arm-linux-gnueabihf/libcrypto.so.1.0.0
766f0000-766fd000 r--p 00145000 b3:02 25944      /usr/lib/arm-linux-gnueabihf/libcrypto.so.1.0.0
766fd000-76705000 rw-p 00152000 b3:02 25944      /usr/lib/arm-linux-gnueabihf/libcrypto.so.1.0.0
76705000-76709000 rw-p 00000000 00:00 0 
76709000-7671a000 r-xp 00000000 b3:02 341        /usr/lib/libfreefare.so.0.0.0
7671a000-7672a000 ---p 00011000 b3:02 341        /usr/lib/libfreefare.so.0.0.0
7672a000-7672b000 rw-p 00011000 b3:02 341        /usr/lib/libfreefare.so.0.0.0
7672b000-7672c000 rw-p 00000000 00:00 0 
7672c000-76732000 r-xp 00000000 b3:02 132473     /lib/arm-linux-gnueabihf/libusb-0.1.so.4.4.4
76732000-76741000 ---p 00006000 b3:02 132473     /lib/arm-linux-gnueabihf/libusb-0.1.so.4.4.4
76741000-76742000 r--p 00005000 b3:02 132473     /lib/arm-linux-gnueabihf/libusb-0.1.so.4.4.4
76742000-76743000 rw-p 00006000 b3:02 132473     /lib/arm-linux-gnueabihf/libusb-0.1.so.4.4.4
76743000-76744000 rw-p 00000000 00:00 0 
76744000-76758000 r-xp 00000000 b3:02 31201      /usr/local/lib/libnfc.so.5.0.1
76758000-76768000 ---p 00014000 b3:02 31201      /usr/local/lib/libnfc.so.5.0.1
76768000-7676a000 rw-p 00014000 b3:02 31201      /usr/local/lib/libnfc.so.5.0.1
7676a000-76787000 r-xp 00000000 b3:02 132408     /lib/arm-linux-gnueabihf/libgcc_s.so.1
76787000-76796000 ---p 0001d000 b3:02 132408     /lib/arm-linux-gnueabihf/libgcc_s.so.1
76796000-76797000 rw-p 0001c000 b3:02 132408     /lib/arm-linux-gnueabihf/libgcc_s.so.1
76797000-7679e000 r-xp 00000000 b3:02 70040      /usr/lib/arm-linux-gnueabihf/libffi.so.6.0.2
7679e000-767ad000 ---p 00007000 b3:02 70040      /usr/lib/arm-linux-gnueabihf/libffi.so.6.0.2
767ad000-767ae000 r--p 00006000 b3:02 70040      /usr/lib/arm-linux-gnueabihf/libffi.so.6.0.2
767ae000-767af000 rw-p 00007000 b3:02 70040      /usr/lib/arm-linux-gnueabihf/libffi.so.6.0.2
767c3000-767e0000 r-xp 00000000 b3:02 779767     /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi_c.so
767e0000-767f0000 ---p 0001d000 b3:02 779767     /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi_c.so
767f0000-767f1000 rw-p 0001d000 b3:02 779767     /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ffi-1.9.18/lib/ffi_c.so
767f1000-767f7000 r-xp 00000000 b3:02 269903     /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/armv7l-linux-eabihf/stringio.so
767f7000-76807000 ---p 00006000 b3:02 269903     /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/armv7l-linux-eabihf/stringio.so
76807000-76808000 rw-p 00006000 b3:02 269903     /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/armv7l-linux-eabihf/stringio.so
76808000-7680a000 r-xp 00000000 b3:02 778268     /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/armv7l-linux-eabihf/enc/trans/transdb.so
7680a000-76819000 ---p 00002000 b3:02 778268     /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/armv7l-linux-eabihf/enc/trans/transdb.so
76819000-7681a000 rw-p 00001000 b3:02 778268     /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/armv7l-linux-eabihf/enc/trans/transdb.so
7681a000-7689b000 rw-p 00000000 00:00 0 
7689b000-76a26000 r--p 00000000 b3:02 129808     /usr/lib/locale/locale-archive
76a26000-76b51000 r-xp 00000000 b3:02 138591     /lib/arm-linux-gnueabihf/libc-2.19.so
76b51000-76b61000 ---p 0012b000 b3:02 138591     /lib/arm-linux-gnueabihf/libc-2.19.so
76b61000-76b63000 r--p 0012b000 b3:02 138591     /lib/arm-linux-gnueabihf/libc-2.19.so
76b63000-76b64000 rw-p 0012d000 b3:02 138591     /lib/arm-linux-gnueabihf/libc-2.19.so
76b64000-76b67000 rw-p 00000000 00:00 0 
76b67000-76bd0000 r-xp 00000000 b3:02 138595     /lib/arm-linux-gnueabihf/libm-2.19.so
76bd0000-76be0000 ---p 00069000 b3:02 138595     /lib/arm-linux-gnueabihf/libm-2.19.so
76be0000-76be1000 r--p 00069000 b3:02 138595     /lib/arm-linux-gnueabihf/libm-2.19.so
76be1000-76be2000 rw-p 0006a000 b3:02 138595     /lib/arm-linux-gnueabihf/libm-2.19.so
76be2000-76be9000 r-xp 00000000 b3:02 138593     /lib/arm-linux-gnueabihf/libcrypt-2.19.so
76be9000-76bf8000 ---p 00007000 b3:02 138593     /lib/arm-linux-gnueabihf/libcrypt-2.19.so
76bf8000-76bf9000 r--p 00006000 b3:02 138593     /lib/arm-linux-gnueabihf/libcrypt-2.19.so
76bf9000-76bfa000 rw-p 00007000 b3:02 138593     /lib/arm-linux-gnueabihf/libcrypt-2.19.so
76bfa000-76c21000 rw-p 00000000 00:00 0 
76c21000-76c23000 r-xp 00000000 b3:02 138594     /lib/arm-linux-gnueabihf/libdl-2.19.so
76c23000-76c32000 ---p 00002000 b3:02 138594     /lib/arm-linux-gnueabihf/libdl-2.19.so
76c32000-76c33000 r--p 00001000 b3:02 138594     /lib/arm-linux-gnueabihf/libdl-2.19.so
76c33000-76c34000 rw-p 00002000 b3:02 138594     /lib/arm-linux-gnueabihf/libdl-2.19.so
76c34000-76c95000 r-xp 00000000 b3:02 26046      /usr/lib/arm-linux-gnueabihf/libgmp.so.10.2.0
76c95000-76ca4000 ---p 00061000 b3:02 26046      /usr/lib/arm-linux-gnueabihf/libgmp.so.10.2.0
76ca4000-76ca5000 r--p 00060000 b3:02 26046      /usr/lib/arm-linux-gnueabihf/libgmp.so.10.2.0
76ca5000-76ca6000 rw-p 00061000 b3:02 26046      /usr/lib/arm-linux-gnueabihf/libgmp.so.10.2.0
76ca6000-76cba000 r-xp 00000000 b3:02 138610     /lib/arm-linux-gnueabihf/libpthread-2.19.so
76cba000-76cca000 ---p 00014000 b3:02 138610     /lib/arm-linux-gnueabihf/libpthread-2.19.so
76cca000-76ccb000 r--p 00014000 b3:02 138610     /lib/arm-linux-gnueabihf/libpthread-2.19.so
76ccb000-76ccc000 rw-p 00015000 b3:02 138610     /lib/arm-linux-gnueabihf/libpthread-2.19.so
76ccc000-76cce000 rw-p 00000000 00:00 0 
76cd0000-76cd2000 r-xp 00000000 b3:02 778291     /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/armv7l-linux-eabihf/enc/encdb.so
76cd2000-76ce1000 ---p 00002000 b3:02 778291     /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/armv7l-linux-eabihf/enc/encdb.so
76ce1000-76ce2000 rw-p 00001000 b3:02 778291     /usr/local/rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/armv7l-linux-eabihf/enc/encdb.so
76ce2000-76f6a000 r-xp 00000000 b3:02 269470     /usr/local/rvm/rubies/ruby-2.4.0/lib/libruby.so.2.4.0
76f6a000-76f79000 ---p 00288000 b3:02 269470     /usr/local/rvm/rubies/ruby-2.4.0/lib/libruby.so.2.4.0
76f79000-76f7e000 rw-p 00287000 b3:02 269470     /usr/local/rvm/rubies/ruby-2.4.0/lib/libruby.so.2.4.0
76f7e000-76f84000 rw-p 00000000 00:00 0 
76f84000-76f89000 r-xp 00000000 b3:02 25886      /usr/lib/arm-linux-gnueabihf/libarmmem.so
76f89000-76f98000 ---p 00005000 b3:02 25886      /usr/lib/arm-linux-gnueabihf/libarmmem.so
76f98000-76f99000 rw-p 00004000 b3:02 25886      /usr/lib/arm-linux-gnueabihf/libarmmem.so
76f99000-76fb9000 r-xp 00000000 b3:02 138588     /lib/arm-linux-gnueabihf/ld-2.19.so
76fbd000-76fbe000 rw-p 00000000 00:00 0 
76fbe000-76fbf000 r-xp 00000000 00:00 0 
76fbf000-76fc0000 ---p 00000000 00:00 0 
76fc0000-76fc3000 rwxp 00000000 00:00 0 
76fc3000-76fc8000 rw-p 00000000 00:00 0 
76fc8000-76fc9000 r--p 0001f000 b3:02 138588     /lib/arm-linux-gnueabihf/ld-2.19.so
76fc9000-76fca000 rw-p 00020000 b3:02 138588     /lib/arm-linux-gnueabihf/ld-2.19.so
7e1f4000-7e9f3000 rwxp 00000000 00:00 0          [stack]
7ef6d000-7ef6e000 r-xp 00000000 00:00 0          [sigpage]
7ef6e000-7ef6f000 r--p 00000000 00:00 0          [vvar]
7ef6f000-7ef70000 r-xp 00000000 00:00 0          [vdso]
ffff0000-ffff1000 r-xp 00000000 00:00 0          [vectors]
````

I investigated and found that the @@context pointer is populated and returned in the unless block within the `self.context` method the first time it is invoked, but the second time `self.context` is invoked, nothing is returned, and the resulting `NFC.context` would be a null pointer, causing the error above. 

This PR is to add one line in `self.context` to return @@context regardless of whether it has just been assigned or it has been assigned previously.

Versions:
Ruby: ruby 2.4.0p0 (2016-12-24 revision 57164) [armv7l-linux-eabihf] (I am running this in a Raspberry Pi 3 Model B)
LibFreeFare: libfreefare-0.4.0 (compiled from source)
Libnfc: libnfc-1.7.1 (compiled from source)