### PR TITLE
fix: unknown MIFARE tag error. 

### DIFF
--- a/lib/ruby-nfc/tags/mifare/tag.rb
+++ b/lib/ruby-nfc/tags/mifare/tag.rb
@@ -21,7 +21,7 @@ module Mifare
 	}
 
   # common freefare functions prototypes
-	attach_function :freefare_tag_new, [:pointer, LibNFC::ISO14443a.by_value], :pointer
+	attach_function :freefare_tag_new, [:pointer, LibNFC::Target.by_value], :pointer
 	attach_function :freefare_free_tag, [:pointer], :void
 
   # tag
@@ -37,7 +37,7 @@ module Mifare
 		def initialize(target, reader)
 			super(target, reader)
 
-			@pointer = Mifare.freefare_tag_new(reader.ptr, target[:nti][:nai])
+			@pointer = Mifare.freefare_tag_new(reader.ptr, target)
 
 			raise Mifare::Error, "Unknown mifare tag" if @pointer.null?
 		end


### PR DESCRIPTION
When I run the example script, after fixing it with the change in https://github.com/hexdigest/ruby-nfc/pull/4, I get the following error:
````
D, [2017-06-29T16:39:12.642460 #2212] DEBUG -- : Library version: libnfc-1.7.1-187-g14f48d0
D, [2017-06-29T16:39:12.644949 #2212] DEBUG -- : Available readers: [#<NFC::Reader:0x1851ca8 @name="acr122_usb:001:007", @ptr=nil>]
/usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/tags/mifare/tag.rb:42:in `initialize': Unknown mifare tag (Mifare::Error)
	from /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/tags/mifare/classic.rb:38:in `initialize'
	from /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:65:in `new'
	from /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:65:in `block (3 levels) in poll'
	from /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:63:in `each'
	from /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:63:in `block (2 levels) in poll'
	from /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:57:in `upto'
	from /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:57:in `block in poll'
	from /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:52:in `loop'
	from /usr/local/rvm/gems/ruby-2.4.0@nfctest/gems/ruby-nfc-1.3/lib/ruby-nfc/reader.rb:52:in `poll'
	from reader.rb:15:in `<main>'
````


After tracing the code, I found that in libfreefare/libfreefare/freefare.c, the method `freefare_tag_new` is defined as:
````
freefare_tag_new (nfc_device *device, nfc_target target)
````

However in `ruby-nfc/lib/tags/mifare/tag.rb, the following is defined:
````
attach_function :freefare_tag_new, [:pointer, LibNFC::ISO14443a.by_value], :pointer
````

And the method call is:
````
@pointer = Mifare.freefare_tag_new(reader.ptr, target[:nti][:nai])
````

The pointer type defined and pointer type passed in is not what C the code expects. I applied the changes in this PR, and the reader is able to read the cards properly now.

```
D, [2017-06-29T16:50:46.528022 #2224] DEBUG -- : Library version: libnfc-1.7.1-187-g14f48d0
D, [2017-06-29T16:50:46.530698 #2224] DEBUG -- : Available readers: [#<NFC::Reader:0x1105b90 @name="acr122_usb:001:007", @ptr=nil>]
D, [2017-06-29T16:50:48.417353 #2224] DEBUG -- : Applied Mifare::Classic::Tag: 93c333e3 Mifare Classic 1k SAK: 0x8
D, [2017-06-29T16:50:48.439208 #2224] DEBUG -- : Contents of block 0x04: f4326417358c9f84a5703218a46a18b9
D, [2017-06-29T16:50:48.455867 #2224] DEBUG -- : New value: 5d90abe77bfab41615cfbcca7bdff667
D, [2017-06-29T16:50:55.320939 #2224] DEBUG -- : Applied Mifare::Classic::Tag: 439356e3 Mifare Classic 1k SAK: 0x8
D, [2017-06-29T16:50:55.342727 #2224] DEBUG -- : Contents of block 0x04: 526e27bd7b22e7cf3d5a80b7f6341e88
D, [2017-06-29T16:50:55.359135 #2224] DEBUG -- : New value: 203d449520c98fd1ee74fa39288320ca
````

